### PR TITLE
Remove python3-pbr

### DIFF
--- a/openstack-sushy-tester.Dockerfile
+++ b/openstack-sushy-tester.Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.13
 
 RUN dnf upgrade -y \
- && dnf install -y python3-devel python3-pbr python3-pip \
+ && dnf install -y python3-devel python3-pip \
  && dnf clean all \
  && rm -rf /var/cache/yum \
  && python3 -m pip install tox


### PR DESCRIPTION
It was added by mistake, we should use the package installed with pip