### PR TITLE
Merge Upstream - Handle TransferMethod in vmedia insertion

### DIFF
--- a/releasenotes/notes/handle_transfer_method-a51d5a17e381ebee.yaml
+++ b/releasenotes/notes/handle_transfer_method-a51d5a17e381ebee.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Add TransferMethod for any general error that mentions it.

--- a/sushy/tests/unit/json_samples/transfer_method_required_error.json
+++ b/sushy/tests/unit/json_samples/transfer_method_required_error.json
@@ -1,0 +1,16 @@
+{
+  "error": {
+    "code": "Base.1.4.0.GeneralError",
+    "message": "See ExtendedInfo for more information.",
+    "@Message.ExtendedInfo": [
+      {
+        "@odata.type": "Message.v1_0_6.Message",
+        "MessageId": "Base.1.4.0.GeneralError",
+        "Message": "'TransferMethod' property which is mandatory to complete the action is missing in the request body.",
+        "MessageArgs": [],
+        "Severity": "Critical"
+      }
+    ]
+  }
+}
+

--- a/sushy/tests/unit/resources/manager/test_virtual_media.py
+++ b/sushy/tests/unit/resources/manager/test_virtual_media.py
@@ -207,6 +207,16 @@ class VirtualMediaTestCase(base.TestCase):
         retval = self.sys_virtual_media.is_transfer_protocol_required(error)
         self.assertTrue(retval)
 
+    def test_is_transfer_method_required(self):
+        with open('sushy/tests/unit/json_samples/'
+                  'transfer_method_required_error.json') as f:
+            response_obj = json.load(f)
+        response = mock.Mock(spec=['json', 'status_code'])
+        response.json.return_value = response_obj
+        error = exceptions.HTTPError('POST', 'VirtualMedia', response)
+        retval = self.sys_virtual_media.is_transfer_method_required(error)
+        self.assertTrue(retval)
+
     def test_eject_media_none(self):
         self.sys_virtual_media._actions.eject_media = None
         self.assertRaisesRegex(


### PR DESCRIPTION
This commit adds the TransferMethod to insertmedia calls if necessary.

Some HW require that the TransferMethod is set before inserting virtual media.

Change-Id: I7fc5d41cdcf79d61cb1906f2755f55f284efe766