### PR TITLE
UPSTREAM: <carry>: Do not upgrade test image

### DIFF
--- a/openstack-sushy-tester.Dockerfile
+++ b/openstack-sushy-tester.Dockerfile
@@ -1,7 +1,6 @@
-FROM ubi9
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.14
 
-RUN dnf upgrade -y \
- && dnf install -y python3-devel python3-pip \
+RUN dnf install -y python3-devel python3-pip \
  && dnf clean all \
  && rm -rf /var/cache/yum \
  && python3 -m pip install tox


### PR DESCRIPTION
In general we should not upgrade the base image when building a container as the base image is already rebuilt regularly. Also setting the base image explicitely to one recommended by ART.