### PR TITLE
Name is not mandatory for Storage/StorageControllers

### DIFF
--- a/releasenotes/notes/storage-controller-name-6924b71a97f78481.yaml
+++ b/releasenotes/notes/storage-controller-name-6924b71a97f78481.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The ``Name`` field of a StorageControllers sub-field of a Storage resource
+    is no longer mandatory.

--- a/sushy/resources/system/storage/storage.py
+++ b/sushy/resources/system/storage/storage.py
@@ -34,7 +34,7 @@ class StorageControllersListField(base.ListField):
     member_id = base.Field('MemberId', required=True)
     """Uniquely identifies the member within the collection."""
 
-    name = base.Field('Name', required=True)
+    name = base.Field('Name')
     """The name of the storage controller"""
 
     status = common.StatusField('Status')

--- a/sushy/tests/unit/json_samples/storage.json
+++ b/sushy/tests/unit/json_samples/storage.json
@@ -17,7 +17,6 @@
             "@odata.id": "/redfish/v1/Systems/437XR1138R2/Storage/1#/StorageControllers/0",
             "@odata.type": "#Storage.v1_3_0.StorageController",
             "MemberId": "0",
-            "Name": "Contoso Integrated RAID",
             "Status": {
                 "@odata.type": "#Resource.Status",
                 "State": "Enabled",

--- a/sushy/tests/unit/resources/system/storage/test_storage.py
+++ b/sushy/tests/unit/resources/system/storage/test_storage.py
@@ -125,7 +125,6 @@ class StorageTestCase(base.TestCase):
         self.assertEqual(1, len(controllers))
         controller = controllers[0]
         self.assertEqual('0', controller.member_id)
-        self.assertEqual('Contoso Integrated RAID', controller.name)
         self.assertEqual(res_cons.Health.OK, controller.status.health)
         self.assertEqual(res_cons.State.ENABLED, controller.status.state)
         identifiers = controller.identifiers


### PR DESCRIPTION
Unlike the separate StorageController object, the StorageControllers
sub-fields do not mandate a name, and it's actually missing from some
iLO 5 machines.

Change-Id: I814e01a8487d0432deec32f9653bfd35099ebe69
(cherry picked from commit c589fae847b9da6ccb9801b91673cfae3316c9c1)
