### PR TITLE
When ManagedBy attribute is missing from System retry with Managers

### DIFF
--- a/releasenotes/notes/retry-on-missing-managedby-b2a5240eab8b4262.yaml
+++ b/releasenotes/notes/retry-on-missing-managedby-b2a5240eab8b4262.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Adds the ability to retry an attempt to determine a Manager for a System
+    when ManagedBy attribute is missing but Managers attribute is present.
+    This resolves issues with certain hardware models such as Huawei 1288H.

--- a/sushy/tests/unit/json_samples/system_managedby_missing_manager_present.json
+++ b/sushy/tests/unit/json_samples/system_managedby_missing_manager_present.json
@@ -1,0 +1,166 @@
+{
+    "@odata.type": "#ComputerSystem.v1_10_0.ComputerSystem",
+    "Id": "437XR1138R2",
+    "Name": "WebFrontEnd483",
+    "SystemType": "Physical",
+    "AssetTag": "Chicago-45Z-2381",
+    "Manufacturer": "Contoso",
+    "Model": "3500",
+    "SubModel": "RX",
+    "SKU": "8675309",
+    "SerialNumber": "437XR1138R2",
+    "PartNumber": "224071-J23",
+    "Description": "Web Front End node",
+    "UUID": "38947555-7742-3448-3784-823347823834",
+    "HostName": "web483",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK",
+        "HealthRollup": "OK"
+    },
+    "HostingRoles": [
+    "ApplicationServer"
+    ],
+    "IndicatorLED": "Off",
+    "PowerState": "On",
+    "Boot": {
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideTarget": "Pxe",
+        "BootSourceOverrideTarget@Redfish.AllowableValues": [
+            "None",
+            "Pxe",
+            "Cd",
+            "Usb",
+            "Hdd",
+            "BiosSetup",
+            "Utilities",
+            "Diags",
+            "SDCard",
+            "UefiTarget",
+            "UefiHttp"
+        ],
+        "BootSourceOverrideMode": "UEFI",
+        "UefiTargetBootSourceOverride": "/0x31/0x33/0x01/0x01",
+        "HttpBootUri": "https://Contoso.lan/boot.iso"
+    },
+    "BootProgress": {
+        "LastBootTimeSeconds": 66,
+         "LastState": "OSRunning",
+        "LastStateTime": "2017-05-03T23:12:37-05:00",
+        "OemLastState": "OS foo running."
+    },
+    "TrustedModules": [
+        {
+            "FirmwareVersion": "1.13b",
+            "InterfaceType": "TPM1_2",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            }
+        }
+    ],
+    "Oem": {
+        "Contoso": {
+            "@odata.type": "#Contoso.ComputerSystem",
+            "Name": "Contoso OEM system",
+            "ProductionLocation": {
+                "FacilityName": "PacWest Production Facility",
+                "Country": "USA"
+            }
+        },
+        "Chipwise": {
+            "@odata.type": "#Chipwise.ComputerSystem",
+            "Style": "Executive"
+        }
+    },
+    "BiosVersion": "P79 v1.45 (12/06/2017)",
+    "ProcessorSummary": {
+        "Count": 2,
+        "ProcessorFamily": "Multi-Core Intel(R) Xeon(R) processor 7xxx Series",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollup": "OK"
+        }
+    },
+    "MemorySummary": {
+        "TotalSystemMemoryGiB": 96,
+        "TotalSystemPersistentMemoryGiB": 0,
+        "MemoryMirroring": "None",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollup": "OK"
+        }
+    },
+    "Bios": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Bios"
+    },
+    "SecureBoot": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/SecureBoot"
+    },
+    "Processors": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors"
+    },
+    "Memory": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces"
+    },
+    "SimpleStorage": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/SimpleStorage"
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices"
+    },
+    "Links": {
+        "Chassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1U"
+            }
+        ],
+        "Managers": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ]
+    },
+    "Actions": {
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/437XR1138R2/Actions/ComputerSystem.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn",
+                "PushPowerButton"
+            ],
+            "@Redfish.OperationApplyTimeSupport": {
+                "@odata.type": "#Settings.v1_2_0.OperationApplyTimeSupport",
+                "SupportedValues": [ "Immediate", "AtMaintenanceWindowStart" ],
+                "MaintenanceWindowStartTime": "2017-05-03T23:12:37-05:00",
+                "MaintenanceWindowDurationInSeconds": 600,
+                "MaintenanceWindowResource": {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                }
+            }
+        },
+        "Oem": {
+            "#Contoso.Reset": {
+                "target": "/redfish/v1/Systems/437XR1138R2/Oem/Contoso/Actions/Contoso.Reset"
+            }
+        }
+    },
+    "@Redfish.MaintenanceWindow": {
+        "@odata.type": "#Settings.v1_2_0.MaintenanceWindow",
+        "MaintenanceWindowDurationInSeconds": 1,
+        "MaintenanceWindowStartTime": "2016-03-07T14:44:30-05:05"
+    },
+    "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}


### PR DESCRIPTION
On some hardware, ManagedBy attribute is missing from System and Managers attribute is used instead. This change enables sushy to detect this condition and retry the request, allowing sushy to support such hardware.

Change-Id: Ibc81e64b8ac0533024c203ea48003aea764901c3 (cherry picked from commit dccdadec5ce86a6e1988e345f63e65eb93ccec05)