### PR TITLE
Skipping UsbCd workaround on Supermicro ARS-111GL-NHR

### DIFF
--- a/releasenotes/notes/supermicro-vmedia-dev-workaround-cc7a870c9a99d92b.yaml
+++ b/releasenotes/notes/supermicro-vmedia-dev-workaround-cc7a870c9a99d92b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes incompatibility with SuperMicro ars-111gl-nhr which uses 'Cd' device
+    string for virtual media boot as opposed to 'UsbCd' typical to most
+    SuperMicro servers.

--- a/sushy/tests/unit/resources/system/test_system.py
+++ b/sushy/tests/unit/resources/system/test_system.py
@@ -361,6 +361,23 @@ class SystemTestCase(base.TestCase):
                            'BootSourceOverrideTarget': 'UsbCd'}},
             etag='81802dbf61beb0bd')
 
+    def test_set_system_boot_options_supermicro_usb_cd_boot_ars111glnhr(self):
+        (self.json_doc["Boot"]
+         ["BootSourceOverrideTarget@Redfish.AllowableValues"]).append("UsbCd")
+        self.sys_inst._parse_attributes(self.json_doc)
+
+        self.sys_inst.manufacturer = "supermicro"
+        self.sys_inst.model = "ARS-111GL-NHR"
+        self.sys_inst.set_system_boot_options(
+            target=sushy.BootSource.CD,
+            enabled=sushy.BootSourceOverrideEnabled.ONCE)
+
+        self.sys_inst._conn.patch.assert_called_once_with(
+            '/redfish/v1/Systems/437XR1138R2',
+            data={'Boot': {'BootSourceOverrideEnabled': 'Once',
+                           'BootSourceOverrideTarget': 'Cd'}},
+            etag='81802dbf61beb0bd')
+
     def test_set_system_boot_options_supermicro_no_usb_cd_boot(self):
 
         self.sys_inst.manufacturer = "supermicro"


### PR DESCRIPTION
Most SuperMicro machines (e.g. X11 and X12 models) use "UsbCd" device string for CD based virtual media however it seems that certain models such as ARS-111GL-NHR require more common "Cd" instead.

This change adds conditional logic which prevents applying "UsbCd" on SuperMicro ARS-111GL-NHR model specifically.

Change-Id: I11696bc158b89fda23ce328c7f34773b093b0575 (cherry picked from commit 595ffbcff4a53eb73fdedb9587ba421558ef6967)