### PR TITLE
[release-4.21] Revert "Skipping UsbCd workaround on Supermicro ARS-111GL-NHR"

### DIFF
--- a/releasenotes/notes/revert-supermicro-ars111gl-cd-workaround-e59d74a33b6ce10f.yaml
+++ b/releasenotes/notes/revert-supermicro-ars111gl-cd-workaround-e59d74a33b6ce10f.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    Fixes virtual media boot failure on Supermicro ARS-111GL-NHR with newer
+    BMC firmware, where the virtual media device string has changed back to
+    'UsbCd' consistent with other Supermicro servers. The model-specific
+    exception that previously skipped the CD-to-UsbCd override for this model
+    has been reverted.
+upgrade:
+  - |
+    The CD-to-UsbCd boot source override is now applied unconditionally to all
+    Supermicro machines. Users running older ARS-111GL-NHR firmware where 'Cd'
+    was the correct virtual media device string will need to upgrade their BMC
+    firmware.

--- a/sushy/resources/system/system.py
+++ b/sushy/resources/system/system.py
@@ -252,7 +252,6 @@ class System(base.ResourceBase):
     of a Resource
     Ref: http://redfish.dmtf.org/schemas/DSP0266_1.7.0.html#settings-resource
     """
-    _supermicro_models_cd_vmedia = frozenset(['ars-111gl-nhr'])
 
     _actions = ActionsField('Actions', required=True)
 
@@ -377,20 +376,14 @@ class System(base.ResourceBase):
 
             target = sys_cons.BootSource(target)
             # NOTE(janders) on SuperMicro X11 and X12 machines, virtual media
-            # is presented as an "USB CD" drive as opposed to a CD drive.
-            # On Supermicro ARS-111GL-NHR however, a more common "CD" device
-            # is used. On both "families" of hardware, both "USB CD" and "CD"
+            # is presented as an "USB CD" drive as opposed to a CD drive. Both
             # are present in the list of boot devices, however only selecting
-            # the appropriate one for the platform as the boot source results
-            # in a successful boot from vMedia. Unless the appropriate option
-            # for a given model is selected, boot fails even if vMedia is
+            # UsbCd as the boot source results in a successful boot from
+            # vMedia. If "CD" is selected, boot fails even if vMedia is
             # inserted. This code detects a case where a SuperMicro machine is
             # about to attempt boot from CD and overrides the boot device to
-            # UsbCd if required, depending on the model. This makes boot from
-            # vMedia work as expected on both variants.
+            # UsbCd instead which makes boot from vMedia work as expected.
             if (self.manufacturer and self.manufacturer.lower() == 'supermicro'
-                    and self.model.lower() not in
-                    self._supermicro_models_cd_vmedia
                     and target == sys_cons.BootSource.CD
                     and sys_cons.BootSource.USB_CD.value
                     in self.boot.allowed_values):

--- a/sushy/tests/unit/resources/system/test_system.py
+++ b/sushy/tests/unit/resources/system/test_system.py
@@ -361,23 +361,6 @@ class SystemTestCase(base.TestCase):
                            'BootSourceOverrideTarget': 'UsbCd'}},
             etag='81802dbf61beb0bd')
 
-    def test_set_system_boot_options_supermicro_usb_cd_boot_ars111glnhr(self):
-        (self.json_doc["Boot"]
-         ["BootSourceOverrideTarget@Redfish.AllowableValues"]).append("UsbCd")
-        self.sys_inst._parse_attributes(self.json_doc)
-
-        self.sys_inst.manufacturer = "supermicro"
-        self.sys_inst.model = "ARS-111GL-NHR"
-        self.sys_inst.set_system_boot_options(
-            target=sushy.BootSource.CD,
-            enabled=sushy.BootSourceOverrideEnabled.ONCE)
-
-        self.sys_inst._conn.patch.assert_called_once_with(
-            '/redfish/v1/Systems/437XR1138R2',
-            data={'Boot': {'BootSourceOverrideEnabled': 'Once',
-                           'BootSourceOverrideTarget': 'Cd'}},
-            etag='81802dbf61beb0bd')
-
     def test_set_system_boot_options_supermicro_no_usb_cd_boot(self):
 
         self.sys_inst.manufacturer = "supermicro"


### PR DESCRIPTION
This reverts commit 595ffbcff4a53eb73fdedb9587ba421558ef6967.

Newer firmware on the Supermicro ARS-111GL-NHR has changed the virtual media device string back to 'UsbCd', consistent with other Supermicro servers. The model-specific exception that skipped the CD-to-UsbCd override for this model is no longer correct and causes boot from virtual media to fail on machines running updated firmware.

Revert the workaround to restore the unconditional CD-to-UsbCd boot source override for all Supermicro machines. Users running older ARS-111GL-NHR firmware where 'Cd' was the correct device will need to update their BMC firmware.

Change-Id: I188e7fb3a60868cfa1ec9428dc974528d2db8e7b

Assisted-By: Claude Opus 4.6
(cherry picked from commit 950648a0af4f79239f3f379c57edda03ef7e0e2e)