### PR TITLE
[release-4.20] Handle missing RelatedProperties in TransferProtocolType detection

### DIFF
--- a/releasenotes/notes/cisco-c845a-transfer-protocol-fix-3791162410459a33.yaml
+++ b/releasenotes/notes/cisco-c845a-transfer-protocol-fix-3791162410459a33.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixes virtual media insertion on BMCs (such as Cisco C845A M8 with
+    Redfish Base.1.18.1) that return ``ActionParameterMissing`` for the
+    missing ``TransferProtocolType`` parameter without including a
+    ``RelatedProperties`` field in the error response. The
+    ``is_transfer_protocol_required`` method now also checks for the
+    parameter name in ``MessageArgs`` as a fallback.

--- a/sushy/tests/unit/json_samples/transfer_proto_required_error4.json
+++ b/sushy/tests/unit/json_samples/transfer_proto_required_error4.json
@@ -1,0 +1,19 @@
+{
+  "error": {
+    "@Message.ExtendedInfo": [
+      {
+        "@odata.type": "#Message.v1_1_1.Message",
+        "Message": "The action InsertMedia requires the parameter TransferProtocolType to be present in the request body.",
+        "MessageArgs": [
+          "InsertMedia",
+          "TransferProtocolType"
+        ],
+        "MessageId": "Base.1.18.1.ActionParameterMissing",
+        "MessageSeverity": "Critical",
+        "Resolution": "Supply the action with the required parameter in the request body when the request is resubmitted."
+      }
+    ],
+    "code": "Base.1.18.1.ActionParameterMissing",
+    "message": "The action InsertMedia requires the parameter TransferProtocolType to be present in the request body."
+  }
+}

--- a/sushy/tests/unit/resources/manager/test_virtual_media.py
+++ b/sushy/tests/unit/resources/manager/test_virtual_media.py
@@ -254,6 +254,16 @@ class VirtualMediaTestCase(base.TestCase):
         retval = self.sys_virtual_media.is_transfer_protocol_required(error)
         self.assertTrue(retval)
 
+    def test_is_transfer_protocol_required_no_related_properties(self):
+        with open('sushy/tests/unit/json_samples/'
+                  'transfer_proto_required_error4.json') as f:
+            response_obj = json.load(f)
+        response = mock.Mock(spec=['json', 'status_code'])
+        response.json.return_value = response_obj
+        error = exceptions.HTTPError('POST', 'VirtualMedia', response)
+        retval = self.sys_virtual_media.is_transfer_protocol_required(error)
+        self.assertTrue(retval)
+
     def test_is_transfer_method_required(self):
         with open('sushy/tests/unit/json_samples/'
                   'transfer_method_required_error.json') as f:


### PR DESCRIPTION
Some BMCs (e.g. Cisco C845A M8 with Redfish Base.1.18.1) return ActionParameterMissing without RelatedProperties, only providing the missing parameter name in MessageArgs. The is_transfer_protocol_required method now checks MessageArgs as a fallback, enabling the automatic retry with TransferProtocolType.

Change-Id: I1dc23853099533817b74a8a47767ff52dc6e99e2

Assisted-By: Claude Code Sonnet 4.6
(cherry picked from commit c161b3a1dc5b3a6cc2a50d52ff4a0c9fce6b5e0e) (cherry picked from commit 3d4283efe1b71a979fe24a25089ad7361375a1f6)