### PR TITLE
[DNM] [cluster-bot] Fix virtual media boot on Quanta QuantaEdge EGN77C-2U

### DIFF
--- a/releasenotes/notes/quanta-egn77c-vmedia-boot-target-3a3d3b1e0c9d2f47.yaml
+++ b/releasenotes/notes/quanta-egn77c-vmedia-boot-target-3a3d3b1e0c9d2f47.yaml
@@ -1,0 +1,19 @@
+---
+fixes:
+  - |
+    Fixes booting from virtual media on Quanta QuantaEdge EGN77C-2U machines.
+    These BMCs present virtual media to the host as a USB removable device,
+    and the host fails to boot when ``Cd`` is requested as the boot source
+    override target even though the media is correctly inserted. ``Usb`` is
+    now sent instead on these machines. Other Quanta models, which expose a
+    conventional virtual optical device, are unaffected.
+upgrade:
+  - |
+    The SuperMicro ``Cd`` to ``UsbCd`` boot source override substitution and
+    the new Quanta ``Cd`` to ``Usb`` substitution are now driven by the
+    ``sushy.resources.system.system.BOOT_SOURCE_TARGET_QUIRKS`` table. The
+    SuperMicro manufacturer check has been relaxed from an exact match to a
+    case-insensitive substring match; substitutions continue to be applied
+    only when the replacement target is advertised by the BMC in
+    ``BootSourceOverrideTarget@Redfish.AllowableValues``. Substitutions are
+    now logged at ``INFO`` rather than ``DEBUG``.

--- a/sushy/resources/system/system.py
+++ b/sushy/resources/system/system.py
@@ -44,6 +44,33 @@ LOG = logging.getLogger(__name__)
 
 EXPAND_QUERY = '?$expand=.($levels=1)'
 
+# Some BMCs present virtual media to the host as a device class that does not
+# match the media type advertised by the VirtualMedia resource. Redfish offers
+# no way to discover this: MediaTypes describes the BMC-side emulated device,
+# BootSourceOverrideTarget describes the host-side enumeration, and nothing in
+# the data model links the two.
+#
+# Entries are (manufacturer, model, from_target, to_target). Manufacturer and
+# model are matched as case-insensitive substrings; a model of None matches any
+# model. A substitution is applied only when the replacement target is
+# advertised in BootSourceOverrideTarget@Redfish.AllowableValues, so an
+# over-broad match cannot produce a request the BMC would reject.
+BOOT_SOURCE_TARGET_QUIRKS = [
+    # SuperMicro presents virtual media as a USB CD drive. Both Cd and UsbCd
+    # are offered, but only UsbCd boots; selecting Cd fails even with media
+    # inserted. First reported on X11/X12, since observed on ARS-111GL-NHR
+    # (ARMv9), so this is not tied to a board generation.
+    ('supermicro', None,
+     sys_cons.BootSource.CD, sys_cons.BootSource.USB_CD),
+    # Quanta QuantaEdge EGN77C-2U (OpenBMC) presents virtual media as a USB
+    # removable device: the slots are named USB1/USB2 and report
+    # "Virtual Removable Media". UsbCd is not offered and Usb is the only
+    # working target. Other QuantaGrid models expose a plain optical CD1 slot
+    # and must not be rewritten, hence the model match.
+    ('quanta', 'egn77c',
+     sys_cons.BootSource.CD, sys_cons.BootSource.USB),
+]
+
 
 class ActionsField(base.CompositeField):
     reset = common.ResetActionField('#ComputerSystem.Reset')
@@ -334,6 +361,37 @@ class System(base.ResourceBase):
         return {v for v in sys_cons.BootSource
                 if v.value in self.boot.allowed_values}
 
+    def _apply_boot_source_target_quirks(self, target):
+        """Apply vendor quirks to a requested boot source target.
+
+        Some BMCs require a boot source target that does not correspond to the
+        media type of the device the image was inserted into. See
+        :data:`BOOT_SOURCE_TARGET_QUIRKS` for the rationale.
+
+        :param target: the requested :py:class:`sushy.BootSource` value.
+        :returns: the target to actually send to the BMC, which is ``target``
+            itself when no quirk applies.
+        """
+        manufacturer = (self.manufacturer or '').lower()
+        model = (self.model or '').lower()
+        allowed = (self.boot.allowed_values or []) if self.boot else []
+
+        for quirk_manuf, quirk_model, from_target, to_target in (
+                BOOT_SOURCE_TARGET_QUIRKS):
+            if (quirk_manuf in manufacturer
+                    and (quirk_model is None or quirk_model in model)
+                    and target == from_target
+                    and to_target.value in allowed):
+                LOG.info('Applying boot source target quirk for %(manuf)s '
+                         '%(model)s: overriding requested target %(from)s '
+                         'with %(to)s for System %(identity)s.',
+                         {'manuf': self.manufacturer, 'model': self.model,
+                          'from': from_target.value, 'to': to_target.value,
+                          'identity': self.identity})
+                return to_target
+
+        return target
+
     def set_system_boot_options(self, target=None, enabled=None, mode=None,
                                 http_boot_uri=None):
         """Set boot source and/or boot frequency and/or boot mode.
@@ -377,23 +435,7 @@ class System(base.ResourceBase):
                     valid_values=valid_targets)
 
             target = sys_cons.BootSource(target)
-            # NOTE(janders) on SuperMicro X11 and X12 machines, virtual media
-            # is presented as an "USB CD" drive as opposed to a CD drive. Both
-            # are present in the list of boot devices, however only selecting
-            # UsbCd as the boot source results in a successful boot from
-            # vMedia. If "CD" is selected, boot fails even if vMedia is
-            # inserted. This code detects a case where a SuperMicro machine is
-            # about to attempt boot from CD and overrides the boot device to
-            # UsbCd instead which makes boot from vMedia work as expected.
-            if (self.manufacturer and self.manufacturer.lower() == 'supermicro'
-                    and target == sys_cons.BootSource.CD
-                    and self.boot
-                    and sys_cons.BootSource.USB_CD.value
-                    in self.boot.allowed_values):
-                LOG.debug('Boot from vMedia was requested on a SuperMicro'
-                          'machine. Overriding boot device from %s to %s.',
-                          target, sys_cons.BootSource.USB_CD)
-                target = sys_cons.BootSource.USB_CD
+            target = self._apply_boot_source_target_quirks(target)
             if (settings_resp and "BootSourceOverrideTarget" in
                     settings_boot_section):
                 settings_data['Boot']['BootSourceOverrideTarget'] = \

--- a/sushy/tests/unit/resources/system/test_system.py
+++ b/sushy/tests/unit/resources/system/test_system.py
@@ -362,6 +362,46 @@ class SystemTestCase(base.TestCase):
                            'BootSourceOverrideTarget': 'Cd'}},
             etag='81802dbf61beb0bd')
 
+    def test_set_system_boot_options_quanta_egn77c_usb_boot(self):
+        # Usb is already among the sample's allowable values.
+        self.sys_inst.manufacturer = "Quanta Cloud Technology Inc."
+        self.sys_inst.model = "QuantaEdge EGN77C-2U"
+        self.sys_inst.set_system_boot_options(
+            target=sushy.BootSource.CD,
+            enabled=sushy.BootSourceOverrideEnabled.ONCE)
+
+        self.sys_inst._conn.patch.assert_called_once_with(
+            '/redfish/v1/Systems/437XR1138R2',
+            data={'Boot': {'BootSourceOverrideEnabled': 'Once',
+                           'BootSourceOverrideTarget': 'Usb'}},
+            etag='81802dbf61beb0bd')
+
+    def test_set_system_boot_options_no_quirk_keeps_target(self):
+        # Advertise both substitution targets, so an over-broad match in the
+        # quirk table shows up here instead of being masked by the
+        # allowable-values guard. QuantaGrid shares a manufacturer with the
+        # quirked EGN77C-2U and must not be rewritten.
+        (self.json_doc["Boot"]
+         ["BootSourceOverrideTarget@Redfish.AllowableValues"]).append("UsbCd")
+        self.sys_inst._parse_attributes(self.json_doc)
+
+        for manufacturer, model in [
+                ('Dell Inc.', 'PowerEdge R640'),
+                ('Quanta Cloud Technology Inc.', 'QuantaGrid S74G-2U')]:
+            with self.subTest(manufacturer=manufacturer):
+                self.sys_inst._conn.patch.reset_mock()
+                self.sys_inst.manufacturer = manufacturer
+                self.sys_inst.model = model
+                self.sys_inst.set_system_boot_options(
+                    target=sushy.BootSource.CD,
+                    enabled=sushy.BootSourceOverrideEnabled.ONCE)
+
+                self.sys_inst._conn.patch.assert_called_once_with(
+                    '/redfish/v1/Systems/437XR1138R2',
+                    data={'Boot': {'BootSourceOverrideEnabled': 'Once',
+                                   'BootSourceOverrideTarget': 'Cd'}},
+                    etag='81802dbf61beb0bd')
+
     def test_set_system_boot_options_settings_resource_nokia(self):
         with open('sushy/tests/unit/json_samples/settings-nokia.json') as f:
             settings_obj = json.load(f)


### PR DESCRIPTION
These BMCs present virtual media to the host as a USB removable device (the slots are named USB1/USB2 and report "Virtual Removable Media"), and the host fails to boot when Cd is requested as the boot source override target, even though the media is correctly inserted. UsbCd is not offered by these machines, so Usb is now sent instead.

Redfish provides no way to discover this. MediaTypes describes the BMC-side emulated device while BootSourceOverrideTarget describes the host-side enumeration, and nothing in the data model links the two, so this remains a vendor quirk.

The existing SuperMicro Cd to UsbCd substitution and this one are now driven by a BOOT_SOURCE_TARGET_QUIRKS table matched on manufacturer and optionally model. The model match matters here: QuantaGrid models share a manufacturer string with the EGN77C-2U, expose a conventional virtual optical device, and must not be rewritten. Substitutions continue to be applied only when the replacement target is advertised in BootSourceOverrideTarget@Redfish.AllowableValues.

The SuperMicro manufacturer check is relaxed from an exact match to a case-insensitive substring match, and substitutions are now logged at INFO rather than DEBUG.


Assisted-By: Claude Opus 5 (1M context)
(cherry picked from commit eed027e3df3be6adfcf789dff74523f67d47aa49)